### PR TITLE
Remove obsolete docker compose `version` attribute

### DIFF
--- a/docker-compose.override.yml.dist
+++ b/docker-compose.override.yml.dist
@@ -1,5 +1,3 @@
-version: '3.7'
-
 #services:
 #  db:
 #    ports:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed the `docker-compose.override.yml.dist` file, including all associated configurations for various services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->