### PR TITLE
Fix/install

### DIFF
--- a/.env.dev.dist
+++ b/.env.dev.dist
@@ -1,4 +1,5 @@
 COMPOSE_PROJECT_NAME=tripleperformance
+COMPOSE_PROFILES=min # comma separated values among min,all,piwigo,wordpress
 
 ENV=dev
 DEBUG=true

--- a/engine/php_server/Dockerfile
+++ b/engine/php_server/Dockerfile
@@ -57,7 +57,7 @@ RUN apt-get update \
 RUN a2enmod rewrite headers deflate remoteip
 
 RUN test -z "$DEBUG_TOOLS" || ( \
-       pecl install xdebug-3.3 \ 
+       pecl install xdebug-3.3.2 \
     && docker-php-ext-enable xdebug \
     && echo "xdebug.discover_client_host=on" >> /usr/local/etc/php/conf.d/xdebug.ini \
     && echo "xdebug.mode=debug" >> /usr/local/etc/php/conf.d/xdebug.ini \


### PR DESCRIPTION
- PECL does not want to install an inexact version of an extension Xdebug 3.3 is not a real packaged version, Xdebug 3.3.0 is one
- When running Docker Compose as mentionned in the README (without specifying any profile), Docker Compose start only "not profiled" containers => i stated a default profile by setting `COMPOSE_PROFILES` env var in the `env.dest.dist` file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new environment variable `COMPOSE_PROFILES` for enhanced Docker Compose configuration options.
- **Improvements**
	- Updated the `xdebug` package version and streamlined package installations in the PHP server Dockerfile.
	- Added support for email handling with `msmtp`, including configurations for Mailtrap and SendGrid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->